### PR TITLE
Make background fixed, merge misc stats into single group, and refine stat header spacing

### DIFF
--- a/statsapp/blueprints/home/view_config.py
+++ b/statsapp/blueprints/home/view_config.py
@@ -39,21 +39,17 @@ MISC_STAT_GROUPS = {
             'married_years',
             'children_count',
             'birkenstock_count',
-        ],
-        [
             'piercings_current',
             'piercing_instances',
             'tattoo_count',
-            'surgery_count'
-        ],
-        [
+            'surgery_count',
             'tshirt_size',
             'shoe_size_us_mens',
             'shoe_size_us_womens',
             'dress_size_us',
-            'max_pullup_count'
+            'max_pullup_count',
+            'goal_completion',
         ],
-        ['goal_completion'],
     ]
 }
 

--- a/statsapp/static/style.css
+++ b/statsapp/static/style.css
@@ -59,7 +59,7 @@ body {
     background: radial-gradient(circle at 15% 20%, #263f8f 0%, transparent 35%),
                 radial-gradient(circle at 85% 10%, #6b3ea8 0%, transparent 30%),
                 linear-gradient(150deg, #0b1020 0%, #151b2f 40%, #0d1323 100%);
-    background-attachment: scroll;
+    background-attachment: fixed;
 }
 
 .main {
@@ -107,8 +107,11 @@ body {
 
 .stat-header {
     width: 100%;
-    padding: 20px;
+    padding: 14px 22px;
+    margin: 0 0 8px;
     font-size: 27px;
+    line-height: 1.25;
+    letter-spacing: 0.01em;
     color: #d7ecff;
     background: linear-gradient(135deg, rgba(28, 75, 128, 0.93) 0%, rgba(70, 47, 134, 0.9) 100%);
 }


### PR DESCRIPTION
### Motivation
- Ensure the page background gradient stays stationary while scrolling for a cleaner visual experience.
- Render all miscellaneous statistics together in one container to simplify layout and grouping.
- Improve the stat header spacing and typography for clearer separation and better visual hierarchy.

### Description
- Set `background-attachment` to `fixed` in `statsapp/static/style.css` so the background no longer scrolls with content.
- Consolidated the multiple miscellaneous stat subgroups into a single subgroup in `statsapp/blueprints/home/view_config.py` so they render under one `stats` container.
- Adjusted `.stat-header` padding, added a bottom margin, and refined `line-height` and `letter-spacing` in `statsapp/static/style.css` to improve header spacing.

### Testing
- Ran `pytest -q` which failed in this environment due to `ModuleNotFoundError` caused by the test runner not having the project on `PYTHONPATH`.
- Ran `PYTHONPATH=. pytest -q` which completed with 7 tests passing and 1 failing test (`tests/tasks/test_pull_withings_data.py::test_get_data_and_upsert`) that is a pre-existing failure related to `argparse` consuming pytest arguments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c747a5adc4832c91d411906fc8da0e)