### PR TITLE
Enhance stat headers and spacing between stat groups

### DIFF
--- a/statsapp/static/style.css
+++ b/statsapp/static/style.css
@@ -83,6 +83,9 @@ body {
 
 .stat-container {
    padding: 8px 8px 18px;
+   display: flex;
+   flex-direction: column;
+   gap: 16px;
 }
 
 .stats {
@@ -110,10 +113,19 @@ body {
     padding: 14px 22px;
     margin: 0 0 8px;
     font-size: 27px;
+    font-weight: 600;
     line-height: 1.25;
-    letter-spacing: 0.01em;
-    color: #d7ecff;
-    background: linear-gradient(135deg, rgba(28, 75, 128, 0.93) 0%, rgba(70, 47, 134, 0.9) 100%);
+    letter-spacing: 0.02em;
+    color: #eff7ff;
+    background: linear-gradient(135deg, rgba(42, 106, 176, 0.95) 0%, rgba(106, 65, 191, 0.92) 100%);
+    border: 1px solid rgba(213, 233, 255, 0.4);
+    box-shadow: 0 10px 24px rgba(21, 43, 88, 0.45);
+}
+
+.statgroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .stat .stat-description {


### PR DESCRIPTION
### Motivation
- Improve readability and visual hierarchy by increasing vertical spacing between stat groups and making stat group headers more prominent.

### Description
- Updated `statsapp/static/style.css` to make `.stat-container` a vertical flex container with `gap: 16px`, add a `.statgroup` column flex layout with `gap: 8px`, and emphasize `.stat-header` with increased `font-weight`, brighter gradient, border, and shadow.

### Testing
- No automated tests were run because this is a CSS-only visual update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c749453dd0832c987699cf553cfb14)